### PR TITLE
Resolve crash with NullPointer Exception after Billing Service disconnects

### DIFF
--- a/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/util/IabHelper.java
+++ b/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/util/IabHelper.java
@@ -434,6 +434,7 @@ public class IabHelper {
         throws IabAsyncInProgressException {
         checkNotDisposed();
         checkSetupDone("launchPurchaseFlow");
+        checkServiceConnected("launchPurchaseFlow");
         flagStartAsync("launchPurchaseFlow");
         IabResult result;
 
@@ -520,6 +521,7 @@ public class IabHelper {
 
         checkNotDisposed();
         checkSetupDone("handleActivityResult");
+        checkServiceConnected("handleActivityResult");
 
         // end of async purchase operation that started on launchPurchaseFlow
         flagEndAsync();
@@ -619,6 +621,7 @@ public class IabHelper {
             List<String> moreSubsSkus) throws IabException {
         checkNotDisposed();
         checkSetupDone("queryInventory");
+        checkServiceConnected("queryInventory");
         try {
             Inventory inv = new Inventory();
             int r = queryPurchases(inv, ITEM_TYPE_INAPP);
@@ -689,6 +692,7 @@ public class IabHelper {
         final Handler handler = new Handler();
         checkNotDisposed();
         checkSetupDone("queryInventory");
+        checkServiceConnected("queryInventory");
         flagStartAsync("refresh inventory");
         (new Thread(new Runnable() {
             public void run() {
@@ -733,6 +737,7 @@ public class IabHelper {
     void consume(Purchase itemInfo) throws IabException {
         checkNotDisposed();
         checkSetupDone("consume");
+        checkServiceConnected("consume");
 
         if (!itemInfo.mItemType.equals(ITEM_TYPE_INAPP)) {
             throw new IabException(IABHELPER_INVALID_CONSUMPTION,
@@ -802,6 +807,7 @@ public class IabHelper {
         throws IabAsyncInProgressException {
         checkNotDisposed();
         checkSetupDone("consume");
+        checkServiceConnected("consume");
         List<Purchase> purchases = new ArrayList<Purchase>();
         purchases.add(purchase);
         consumeAsyncInternal(purchases, listener, null);
@@ -816,6 +822,7 @@ public class IabHelper {
         throws IabAsyncInProgressException {
         checkNotDisposed();
         checkSetupDone("consume");
+        checkServiceConnected("consume");
         consumeAsyncInternal(purchases, null, listener);
     }
 
@@ -860,6 +867,15 @@ public class IabHelper {
             logError("Illegal state for operation (" + operation + "): IAB helper is not set up.");
             throw new IllegalStateException("IAB helper is not set up. Can't perform operation: " + operation);
         }
+    }
+
+    // Checks that Billing service is connected; if not, throws an exception.
+    private void checkServiceConnected(String operation) {
+        if (mService == null) {
+            logError("IabHelper.mService is null. Service not connected: " + operation);
+            throw new IllegalStateException("Billing service is disconnected: " + operation);
+        }
+
     }
 
     // Workaround to bug where sometimes response codes come as Long instead of Integer
@@ -937,6 +953,7 @@ public class IabHelper {
         // Query purchases
         logDebug("Querying owned items, item type: " + itemType);
         logDebug("Package name: " + mContext.getPackageName());
+        checkServiceConnected("queryPurchases");
         boolean verificationFailed = false;
         String continueToken = null;
 
@@ -999,6 +1016,7 @@ public class IabHelper {
     int querySkuDetails(String itemType, Inventory inv, List<String> moreSkus)
             throws RemoteException, JSONException {
         logDebug("Querying SKU details.");
+        checkServiceConnected("querySkuDetails");
         ArrayList<String> skuList = new ArrayList<String>();
         skuList.addAll(inv.getAllOwnedSkus(itemType));
         if (moreSkus != null) {


### PR DESCRIPTION
Added new `checkServiceConnected()`  method to `IabHelper` which gets called before code where a connection is essential. Throws exception if not connected to Billing Service.

Works analogously to the current method `checkSetupDone()` 

This would help solve the issue:

https://github.com/googlesamples/android-play-billing/issues/45

The client could wrap calls to `IabHelper` in a try/catch for `IllegalStateException`, reporting a meaningful message (from the specific exception thrown) instead of the confusing` nullpointer exception` that gets thrown currently, when `IabHelper` calls methods on `mService` without checking if its null (which it sometimes unpredictably is)