### PR TITLE
Fix object assign

### DIFF
--- a/ClassyTaxi/firebase/server/src/play-billing/internal/purchases_impl.ts
+++ b/ClassyTaxi/firebase/server/src/play-billing/internal/purchases_impl.ts
@@ -75,7 +75,7 @@ export class OneTimeProductPurchaseImpl implements OneTimeProductPurchase {
     apiResponse.developerPayload = null;
 
     const purchase = new OneTimeProductPurchaseImpl();
-    Object.assign(this, apiResponse);
+    Object.assign(purchase, apiResponse);
     purchase.purchaseToken = purchaseToken;
     purchase.sku = sku;
     purchase.verifiedAt = verifiedAt;


### PR DESCRIPTION
Api response is not assigned properly and this causes unpleasantly improper data that makes registration of products to users impossible.